### PR TITLE
Implement optional SSL verification control

### DIFF
--- a/provider/mineru.yaml
+++ b/provider/mineru.yaml
@@ -44,6 +44,14 @@ credentials_for_provider:
           en_US: MinerU Official API
           ja_JP: MinerU公式API
           zh_Hans: MinerU官方API
+  verify_ssl:
+    label:
+      en_US: Verify SSL
+      ja_JP: SSL証明書を検証する
+      zh_Hans: 验证SSL证书
+    required: false
+    type: boolean
+    default: true
 
 identity:
   author: langgenius


### PR DESCRIPTION
## Summary
- allow disabling SSL verification via a new `verify_ssl` credential
- respect the option when validating credentials and making HTTP requests

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842f7cd8184832a910e9af2b4e8b236